### PR TITLE
Save address with checksum when signing into room

### DIFF
--- a/packages/backend/functions/handlers/signRoom.js
+++ b/packages/backend/functions/handlers/signRoom.js
@@ -6,7 +6,7 @@ module.exports = functions.https.onCall((data, context) => {
   const { room, signature } = data;
 
   // recover address from signature
-  const recovered = ethers.utils.verifyMessage(room, signature).toLowerCase();
+  const recovered = ethers.utils.verifyMessage(room, signature);
 
   // validate address
   if (!ethers.utils.isAddress(recovered)) {


### PR DESCRIPTION
Maybe is better to save the address with the checksum in the rooms. Then when a user export the address list he will get the list with the checksum to be able to check that the addresses are right.