### PR TITLE
fixed blockie size & alignment in Guest/Host Room lists

### DIFF
--- a/packages/react-app/src/components/Address.jsx
+++ b/packages/react-app/src/components/Address.jsx
@@ -91,6 +91,7 @@ export default function Address(props) {
         title={text}
         description={props.extra}
         key="meta"
+        style={{ display: "flex", alignItems: "center" }}
       />
     </div>
   );

--- a/packages/react-app/src/views/GuestRoom.jsx
+++ b/packages/react-app/src/views/GuestRoom.jsx
@@ -343,7 +343,7 @@ export default function GuestRoom({
                                   alignItems: "center",
                                 }}
                               >
-                                <Address address={item} ensProvider={mainnetProvider} fontSize={14} />
+                                <Address address={item} ensProvider={mainnetProvider} fontSize={28} />
                               </div>
                             </List.Item>
                           )}

--- a/packages/react-app/src/views/HostRoom.jsx
+++ b/packages/react-app/src/views/HostRoom.jsx
@@ -533,7 +533,7 @@ export default function HostRoom({
                                   alignItems: "center",
                                 }}
                               >
-                                <Address address={item} ensProvider={mainnetProvider} fontSize={14} />
+                                <Address address={item} ensProvider={mainnetProvider} fontSize={28} />
                                 {importedAddresses.includes(item) && <Tag color="grey">imported</Tag>}
                                 <Button
                                   onClick={() => {
@@ -579,7 +579,7 @@ export default function HostRoom({
                                   alignItems: "center",
                                 }}
                               >
-                                <Address address={item} ensProvider={mainnetProvider} fontSize={12} />
+                                <Address address={item} ensProvider={mainnetProvider} fontSize={28} />
                                 <Button onClick={() => reList(index)} size="medium">
                                   <CloseOutlined />
                                 </Button>


### PR DESCRIPTION
Fixes #354 

Found to be an issue in the HostRoom lists in addition to GuestRoom list. Fixed in both instances

Regarding _**Acceptance criteria**_:
- [x]  Blockie should be inline with address
- [x] Blockie height should be almost the same as the guest list text font
- [x] Navbar Current User Address Blockie should remain the same

The fix has the side benefit of the **Navbar Current User Address Blockie** being more centrally aligned as well.

GuestRoom list:
![roomList_fixed](https://user-images.githubusercontent.com/29999494/156228594-763ff189-2410-46ff-825e-854048db8463.PNG)

HostRoom list:
![hostLists_fixed](https://user-images.githubusercontent.com/29999494/156228690-a919bba2-15e7-44e1-8a3e-9c980375c218.PNG)

